### PR TITLE
nobservation strategy

### DIFF
--- a/conf/fink_alert_simulator.conf
+++ b/conf/fink_alert_simulator.conf
@@ -33,7 +33,7 @@ NALERTS_PER_OBS=3
 
 # Number of observations to make - note that the total
 # number of alerts will be NALERTS_PER_OBS * NOBSERVATIONS
-NOBSERVATIONS=3
+NOBSERVATIONS=4
 
 # Time between 2 observations (second)
 TIME_INTERVAL=5

--- a/conf/fink_alert_simulator.conf
+++ b/conf/fink_alert_simulator.conf
@@ -31,8 +31,9 @@ FINK_DATA_SIM=${FINK_ALERT_SIMULATOR}/datasim
 # Number of alerts to send simultaneously per observations.
 NALERTS_PER_OBS=3
 
-# Number of observations to make - note that the total
+# Number of observations to make. Note that the total
 # number of alerts will be NALERTS_PER_OBS * NOBSERVATIONS
+# Set it to -1 if you want all alerts to be sent.
 NOBSERVATIONS=4
 
 # Time between 2 observations (second)

--- a/fink_alert_simulator/alertProducer.py
+++ b/fink_alert_simulator/alertProducer.py
@@ -84,7 +84,7 @@ def schedule_delays(
     for arg in argslist:
         wait_time = interval - (time.time() % interval)
         yield from asyncio.ensure_future(delay(wait_time, function, arg))
-        print('Alert sent: {}'.format(counter))
+        print('Observation {} done...'.format(counter))
         counter += 1
     eventloop.stop()
 


### PR DESCRIPTION
The input variable `nobservations` defines the number of observations to run (each containing nalert_per_observation). If `nobservations * nalert_per_observation` is greater than the total number of alerts, or if it is set to `-1`, then it will be changed such that all available alerts are taken.