### PR TITLE
Allow reading gzipped input avro files

### DIFF
--- a/bin/fink_simulator
+++ b/bin/fink_simulator
@@ -82,4 +82,5 @@ fi
 # Launch the simulator
 python3 ${FINK_ALERT_SIMULATOR}/bin/simulate_stream.py ${HELP_ON_SERVICE} \
   -servers ${KAFKA_IPPORT} -topic ${KAFKA_TOPIC} -datasimpath ${FINK_DATA_SIM}\
-  -tinterval_kafka ${TIME_INTERVAL} -nobservations ${NOBSERVATIONS} -nalerts_per_obs $NALERTS_PER_OBS
+  -tinterval_kafka ${TIME_INTERVAL} -nobservations ${NOBSERVATIONS}\
+  -nalerts_per_obs $NALERTS_PER_OBS -to_display ${DISPLAY_FIELD}

--- a/bin/simulate_stream.py
+++ b/bin/simulate_stream.py
@@ -106,7 +106,7 @@ def main():
                 """.format(fn)
                 raise NotImplementedError(msg)
 
-            with copen(fn, mode='rb') as file_data:
+            with copen(fn) as file_data:
                 # Read the data
                 data = avroUtils.readschemadata(file_data)
 

--- a/conf/fink_alert_simulator.conf
+++ b/conf/fink_alert_simulator.conf
@@ -28,6 +28,10 @@ KAFKA_TOPIC="ztf-stream-sim"
 # Where the data for sims is
 FINK_DATA_SIM=${FINK_ALERT_SIMULATOR}/datasim
 
+# Which alert field to display on the screen to follow the stream progression
+# Only top-level fields are accepted. If None, does not display anything.
+DISPLAY_FIELD=objectId
+
 # Number of alerts to send simultaneously per observations.
 NALERTS_PER_OBS=3
 

--- a/fink_alert_simulator/parser.py
+++ b/fink_alert_simulator/parser.py
@@ -74,6 +74,13 @@ def getargs(parser: argparse.ArgumentParser) -> argparse.Namespace:
         Folder containing simulated alerts to be published by Kafka.
         [FINK_DATA_SIM]
         """)
+    parser.add_argument(
+        '-to_display', type=str, default='None',
+        help="""
+        Alert field to display on the screen to follow the stream progression
+        Only top-level fields are accepted.
+        [DISPLAY_FIELD]
+        """)
     args = parser.parse_args(None)
     return args
 


### PR DESCRIPTION
Closes #14 

This PR allows to input `avro` or `avro.gz` files to the simulator. Internally, the code checks for the extension, hence it should be explicit. This is part of the work for ELaSTICC.