### PR TITLE
Allow the display of non top-level fields

### DIFF
--- a/bin/simulate_stream.py
+++ b/bin/simulate_stream.py
@@ -117,7 +117,11 @@ def main():
                 record = data.next()
                 if index == 0 or index == len(list_of_files) - 1:
                     if args.to_display != 'None':
-                        startstop.append(record[args.to_display])
+                        fields = args.to_display.split(',')
+                        to_display = record[fields[0]]
+                        for field_ in fields[1:]:
+                            to_display = to_display[field_]
+                        startstop.append(to_display)
                 streamproducer.send(record, alert_schema=schema, encode=True)
 
         if args.to_display != 'None':

--- a/conf/fink_alert_simulator.conf
+++ b/conf/fink_alert_simulator.conf
@@ -29,7 +29,10 @@ KAFKA_TOPIC="ztf-stream-sim"
 FINK_DATA_SIM=${FINK_ALERT_SIMULATOR}/datasim
 
 # Which alert field to display on the screen to follow the stream progression
-# Only top-level fields are accepted. If None, does not display anything.
+# Field names should be comma-separated, starting from top-level.
+# e.g. for ZTF you would do `objectId` for displaying record[`objectId`], but
+# `candidate,jd` to display record['candidate']['jd']
+# If None, does not display anything.
 DISPLAY_FIELD=objectId
 
 # Number of alerts to send simultaneously per observations.

--- a/fink_alert_simulator/parser.py
+++ b/fink_alert_simulator/parser.py
@@ -78,7 +78,10 @@ def getargs(parser: argparse.ArgumentParser) -> argparse.Namespace:
         '-to_display', type=str, default='None',
         help="""
         Alert field to display on the screen to follow the stream progression
-        Only top-level fields are accepted.
+        Field names should be comma-separated, starting from top-level.
+        e.g. for ZTF you would do `objectId` for displaying record[`objectId`],
+        and `candidate,jd` to display record['candidate']['jd']
+        If None, does not display anything.
         [DISPLAY_FIELD]
         """)
     args = parser.parse_args(None)


### PR DESCRIPTION
Closes #16

This PR allows the user to display any alert field when watching the stream progression:

```bash
# Field names should be comma-separated, starting from top-level.
# e.g. for ZTF you would do `objectId` for displaying record[`objectId`], but
# `candidate,jd` to display record['candidate']['jd']
# If None, does not display anything.
DISPLAY_FIELD=objectId
```