### PR TITLE
Process schemaless alerts

### DIFF
--- a/conf/fink_alert_simulator.conf
+++ b/conf/fink_alert_simulator.conf
@@ -49,3 +49,6 @@ NOBSERVATIONS=4
 
 # Time between 2 observations (second)
 TIME_INTERVAL=5
+
+# Path to external avro schema. 'None' if not required.
+EXTERNAL_SCHEMA='None'

--- a/rootfs/fink/bin/fink_simulator
+++ b/rootfs/fink/bin/fink_simulator
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2019 AstroLab Software
+# Copyright 2019-2023 AstroLab Software
 # Author: Julien Peloton
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -87,4 +87,5 @@ fi
 simulate_stream \
   -servers ${KAFKA_IPPORT} -topic ${KAFKA_TOPIC} -datasimpath ${FINK_DATA_SIM}\
   -tinterval_kafka ${TIME_INTERVAL} -nobservations ${NOBSERVATIONS}\
-  -nalerts_per_obs $NALERTS_PER_OBS -to_display ${DISPLAY_FIELD}
+  -nalerts_per_obs $NALERTS_PER_OBS -external_schema=${EXTERNAL_SCHEMA}\
+  -to_display ${DISPLAY_FIELD}

--- a/rootfs/fink/bin/simulate_stream
+++ b/rootfs/fink/bin/simulate_stream
@@ -40,6 +40,9 @@ def main():
     streamproducer = alertProducer.AlertProducer(
         args.topic, schema_files=None, **conf)
 
+    if args.external_schema != 'None':
+        schema = fastavro.schema.load_schema(args.external_schema)
+
     # Scan for avro files
     root = args.datasimpath
 

--- a/rootfs/fink/bin/simulate_stream
+++ b/rootfs/fink/bin/simulate_stream
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2019-2022 AstroLab Software
+# Copyright 2019-2023 AstroLab Software
 # Author: Julien Peloton
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -80,7 +80,7 @@ def main():
     t0 = time.time()
     print("t0: {}".format(t0))
 
-    def send_visit(list_of_files):
+    def send_visit_internal_schema(list_of_files):
         """ Send all alerts of an observation for publication in Kafka
 
         Parameters
@@ -132,6 +132,50 @@ def main():
 
         # Trigger the producer
         streamproducer.flush()
+
+    def send_visit_external_schema(list_of_files):
+        """ Send all alerts of an observation for publication in Kafka
+
+        Requires external schema to be defined.
+
+        Parameters
+        ----------
+        list_of_files: list of str
+            List with filenames containing the alert (avro file). Alerts
+            can be gzipped, but the extension should be
+            explicit (`avro` or `avro.gz`).
+        """
+        print('Observation start: t0 + : {:.2f} seconds'.format(
+            time.time() - t0))
+        # Load alert contents
+        startstop = []
+        for index, fn in enumerate(list_of_files):
+            with open(fn, 'rb') as fp:
+                record = fastavro.schemaless_reader(fp, schema)
+
+                if index == 0 or index == len(list_of_files) - 1:
+                    if args.to_display != 'None':
+                        fields = args.to_display.split(',')
+                        to_display = record[fields[0]]
+                        for field_ in fields[1:]:
+                            to_display = to_display[field_]
+                        startstop.append(to_display)
+                streamproducer.send(record, alert_schema=schema, encode=True)
+
+        if args.to_display != 'None':
+            print('{} alerts sent ({} to {})'.format(len(
+                list_of_files),
+                startstop[0],
+                startstop[1]))
+
+        # Trigger the producer
+        streamproducer.flush()
+
+
+    if args.external_schema != 'None':
+        send_visit = send_visit_external_schema
+    else:
+        send_visit = send_visit_internal_schema
 
     loop = asyncio.get_event_loop()
     asyncio.ensure_future(

--- a/rootfs/fink/bin/simulate_stream
+++ b/rootfs/fink/bin/simulate_stream
@@ -22,6 +22,7 @@ import glob
 import time
 import asyncio
 import gzip
+import fastavro
 
 import numpy as np
 

--- a/rootfs/fink/fink_alert_simulator/alertProducer.py
+++ b/rootfs/fink/fink_alert_simulator/alertProducer.py
@@ -17,6 +17,7 @@ import time
 import os
 import sys
 import asyncio
+import fastavro
 
 from typing import Any
 from types import FunctionType

--- a/rootfs/fink/fink_alert_simulator/alertProducer.py
+++ b/rootfs/fink/fink_alert_simulator/alertProducer.py
@@ -142,6 +142,7 @@ class AlertProducer(object):
         """
         if encode is True:
             if alert_schema is None:
+                # BUG: self.alert_schema is never defined
                 avro_bytes = avroUtils.writeavrodata(data, self.alert_schema)
             else:
                 avro_bytes = avroUtils.writeavrodata(data, alert_schema)

--- a/rootfs/fink/fink_alert_simulator/alertProducer.py
+++ b/rootfs/fink/fink_alert_simulator/alertProducer.py
@@ -17,7 +17,6 @@ import time
 import os
 import sys
 import asyncio
-import fastavro
 
 from typing import Any
 from types import FunctionType

--- a/rootfs/fink/fink_alert_simulator/parser.py
+++ b/rootfs/fink/fink_alert_simulator/parser.py
@@ -84,6 +84,13 @@ def getargs(parser: argparse.ArgumentParser) -> argparse.Namespace:
         If None, does not display anything.
         [DISPLAY_FIELD]
         """)
+    parser.add_argument(
+        '-external_schema', type=str, default='None',
+        help="""
+        If provided, the avro schema (.avsc) will be used to read alerts.
+        [EXTERNAL_SCHEMA]
+        """
+    )
     args = parser.parse_args(None)
     return args
 


### PR DESCRIPTION
This PR enables stream generation using schemaless alerts as input. The schema needs to the pass in the configuration file `EXTERNAL_SCHEMA=<path>`.

Missing:
- [x] refactor the simulator code to better handle alerts w/ and w/o schema
- [ ] add unit tests