### PR TITLE
Distribute data accross partitions

### DIFF
--- a/conf/fink_alert_simulator.conf
+++ b/conf/fink_alert_simulator.conf
@@ -52,3 +52,6 @@ TIME_INTERVAL=5
 
 # Path to external avro schema. 'None' if not required.
 EXTERNAL_SCHEMA='None'
+
+# Number of partitions
+NPARTITIONS=10

--- a/rootfs/fink/bin/fink_simulator
+++ b/rootfs/fink/bin/fink_simulator
@@ -86,6 +86,6 @@ fi
 # Launch the simulator
 simulate_stream \
   -servers ${KAFKA_IPPORT} -topic ${KAFKA_TOPIC} -datasimpath ${FINK_DATA_SIM}\
-  -tinterval_kafka ${TIME_INTERVAL} -nobservations ${NOBSERVATIONS}\
+  -tinterval_kafka ${TIME_INTERVAL} -nobservations ${NOBSERVATIONS} -npartitions ${NPARTITIONS}\
   -nalerts_per_obs $NALERTS_PER_OBS -external_schema=${EXTERNAL_SCHEMA}\
   -to_display ${DISPLAY_FIELD}

--- a/rootfs/fink/bin/simulate_stream
+++ b/rootfs/fink/bin/simulate_stream
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2019-2023 AstroLab Software
+# Copyright 2019-2024 AstroLab Software
 # Author: Julien Peloton
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -110,6 +110,9 @@ def main():
                 """.format(fn)
                 raise NotImplementedError(msg)
 
+            # assign a partition number
+            partition = np.random.randint(low=0, high=args.npartitions)
+
             with copen(fn) as file_data:
                 # Read the data
                 data = avroUtils.readschemadata(file_data)
@@ -126,7 +129,7 @@ def main():
                         for field_ in fields[1:]:
                             to_display = to_display[field_]
                         startstop.append(to_display)
-                streamproducer.send(record, alert_schema=schema, encode=True)
+                streamproducer.send(record, alert_schema=schema, partition=partition, encode=True)
 
         if args.to_display != 'None':
             print('{} alerts sent ({} to {})'.format(len(
@@ -157,6 +160,9 @@ def main():
             with open(fn, 'rb') as fp:
                 record = fastavro.schemaless_reader(fp, schema)
 
+                # assign a partition number
+                partition = np.random.randint(low=0, high=args.npartitions)
+
                 if index == 0 or index == len(list_of_files) - 1:
                     if args.to_display != 'None':
                         fields = args.to_display.split(',')
@@ -164,7 +170,7 @@ def main():
                         for field_ in fields[1:]:
                             to_display = to_display[field_]
                         startstop.append(to_display)
-                streamproducer.send(record, alert_schema=schema, encode=True)
+                streamproducer.send(record, alert_schema=schema, partition=partition, encode=True)
 
         if args.to_display != 'None':
             print('{} alerts sent ({} to {})'.format(len(

--- a/rootfs/fink/fink_alert_simulator/alertProducer.py
+++ b/rootfs/fink/fink_alert_simulator/alertProducer.py
@@ -1,4 +1,4 @@
-# Copyright 2019 AstroLab Software
+# Copyright 2019-2024 AstroLab Software
 # Author: Maria Patterson, Julien Peloton
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -121,7 +121,7 @@ class AlertProducer(object):
         self.producer = confluent_kafka.Producer(**kwargs)
         self.topic = topic
 
-    def send(self, data: dict, alert_schema: dict = None, encode: bool = False):
+    def send(self, data: dict, alert_schema: dict = None, partition: int = 0, encode: bool = False):
         """Sends a message to Kafka stream.
 
         You can choose to encode or not the message (using avro).
@@ -136,6 +136,8 @@ class AlertProducer(object):
             Data containing message content. If encode is True, expects JSON.
         alert_schema: dict, optional
             Avro schema for encoding data. Default is None.
+        partition: int, optional
+            The partition ID. Default is 0.
         encode : `boolean`, optional
             If True, encodes data to Avro format. If False, sends data raw.
             Default is False.
@@ -147,10 +149,10 @@ class AlertProducer(object):
             else:
                 avro_bytes = avroUtils.writeavrodata(data, alert_schema)
             raw_bytes = avro_bytes.getvalue()
-            self.producer.produce(self.topic, raw_bytes)
+            self.producer.produce(topic=self.topic, value=raw_bytes, partition=partition)
         else:
             data_str = "{}".format(data)
-            self.producer.produce(self.topic, data_str)
+            self.producer.produce(topic=self.topic, value=data_str, partition=partition)
 
     def flush(self):
         """ Publish message to the Kafka cluster.

--- a/rootfs/fink/fink_alert_simulator/parser.py
+++ b/rootfs/fink/fink_alert_simulator/parser.py
@@ -1,4 +1,4 @@
-# Copyright 2019 AstroLab Software
+# Copyright 2019-2024 AstroLab Software
 # Author: Julien Peloton
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -89,6 +89,13 @@ def getargs(parser: argparse.ArgumentParser) -> argparse.Namespace:
         help="""
         If provided, the avro schema (.avsc) will be used to read alerts.
         [EXTERNAL_SCHEMA]
+        """
+    )
+    parser.add_argument(
+        '-npartitions', type=int, default=10,
+        help="""
+        The number of partitions in the Kafka cluster. Default is 10.
+        [NPARTITIONS]
         """
     )
     args = parser.parse_args(None)


### PR DESCRIPTION
Enable to specify the partition number when producing data. It should correspond to the number of partitions set in the Kafka cluster. Ideally, there should be a fallback value to use the internal partitioner (not implemented because the [confluent_kafka documentation](https://docs.confluent.io/platform/current/clients/confluent-kafka-python/html/index.html#confluent_kafka.Producer.produce) does not specify the fallback value).